### PR TITLE
docs: trim README deploy section (link to DEPLOY.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,32 +65,7 @@ cargo build
 
 ---
 
-## Deploy & Ops Quickstart
+## Deploy
 
-See full guide in [`docs/DEPLOY.md`](docs/DEPLOY.md). TL;DR:
-
-```bash
-# 0) Build artifacts
-make wasm
-make abi
-
-# 1) Deploy (prints & caches contract address to scripts/ops/.contract-address)
-SUPER_USER=erd1... MX_NETWORK=devnet MX_WALLET=~/wallets/owner.pem \
-scripts/ops/deploy.sh
-
-# 2) Init (owner-only config)
-FEES_RECEIVER=erd1... PRIZES_RECEIVER=erd1... TOKEN_ID=FOXSY-xxxxxx \
-MIN_REGISTRATION_FEE=1000000000000000000 MIN_PRIZE=100000000000000000000 \
-MIN_REG_TIME=86400 MX_NETWORK=devnet MX_WALLET=~/wallets/owner.pem \
-scripts/ops/init.sh
-
-# 3) Create a tournament (sends prize ESDT)
-T_ID=1 REG_FEE=10000000000000000000 PRIZE=1000000000000000000000 \
-TOKEN_ID=FOXSY-xxxxxx MX_NETWORK=devnet MX_WALLET=~/wallets/owner.pem \
-scripts/ops/create_tournament.sh
-
-# 4) Register (sends fee ESDT)
-TOURNAMENT_ID=1 TEAM_SETUP_ID=42 FEE_AMOUNT=10000000000000000000 \
-TOKEN_ID=FOXSY-xxxxxx MX_NETWORK=devnet MX_WALLET=~/wallets/owner.pem \
-scripts/ops/register.sh
+See full guide in [`docs/DEPLOY.md`](docs/DEPLOY.md).
 


### PR DESCRIPTION
Remove the long Quickstart block from README to avoid duplication; keep a short link to docs/DEPLOY.md.