### PR TITLE
docs: fix README rendering + minimal Deploy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@
 cargo check
 cargo build
 
+```
+
 ---
 
 ## Deploy
 
-See full guide in [`docs/DEPLOY.md`](docs/DEPLOY.md).
+See full guide in [docs/DEPLOY.md](docs/DEPLOY.md).
 


### PR DESCRIPTION
Close stray code fence so README renders correctly and replace long Deploy block with a short link to docs/DEPLOY.md.